### PR TITLE
Support node autodetection via IP address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2024-07-19
+
+### Added
+
+- Supports `/cloud-init[-secure]/{user,meta,vendor}-data` endpoints, which auto-detect the querying node's IP address and look up the corresponding xname in SMD
+  - This is in contrast to the existing MAC-based endpoints, which remain functional
+
 ## [0.1.0] - 2024-07-17
 
 ### Added

--- a/cmd/cloud-init-server/handlers.go
+++ b/cmd/cloud-init-server/handlers.go
@@ -105,46 +105,20 @@ func (h CiHandler) GetEntry(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (h CiHandler) GetUserData(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
-	// Retrieve the node's xname based on MAC address
-	name, err := h.sm.IDfromMAC(id)
-	if err != nil {
-		log.Print(err)
-		name = id // Fall back to using the given name as-is
-	} else {
-		log.Printf("xname %s with mac %s found\n", name, id)
+func (h CiHandler) GetDataByMAC(dataKind ciDataKind) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		// Retrieve the node's xname based on MAC address
+		name, err := h.sm.IDfromMAC(id)
+		if err != nil {
+			log.Print(err)
+			name = id // Fall back to using the given name as-is
+		} else {
+			log.Printf("xname %s with mac %s found\n", name, id)
+		}
+		// Actually respond with the data
+		h.getData(name, dataKind, w)
 	}
-	// Actually respond with the data
-	h.getData(name, UserData, w)
-}
-
-func (h CiHandler) GetMetaData(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
-	// Retrieve the node's xname based on MAC address
-	name, err := h.sm.IDfromMAC(id)
-	if err != nil {
-		log.Print(err)
-		name = id // Fall back to using the given name as-is
-	} else {
-		log.Printf("xname %s with mac %s found\n", name, id)
-	}
-	// Actually respond with the data
-	h.getData(name, MetaData, w)
-}
-
-func (h CiHandler) GetVendorData(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
-	// Retrieve the node's xname based on MAC address
-	name, err := h.sm.IDfromMAC(id)
-	if err != nil {
-		log.Print(err)
-		name = id // Fall back to using the given name as-is
-	} else {
-		log.Printf("xname %s with mac %s found\n", name, id)
-	}
-	// Actually respond with the data
-	h.getData(name, VendorData, w)
 }
 
 func (h CiHandler) getData(id string, dataKind ciDataKind, w http.ResponseWriter) {

--- a/cmd/cloud-init-server/main.go
+++ b/cmd/cloud-init-server/main.go
@@ -84,9 +84,9 @@ func initCiRouter(router chi.Router, handler *CiHandler) {
 	router.Get("/", handler.ListEntries)
 	router.Post("/", handler.AddEntry)
 	router.Get("/{id}", handler.GetEntry)
-	router.Get("/{id}/user-data", handler.GetUserData)
-	router.Get("/{id}/meta-data", handler.GetMetaData)
-	router.Get("/{id}/vendor-data", handler.GetVendorData)
+	router.Get("/{id}/user-data", handler.GetDataByMAC(UserData))
+	router.Get("/{id}/meta-data", handler.GetDataByMAC(MetaData))
+	router.Get("/{id}/vendor-data", handler.GetDataByMAC(VendorData))
 	router.Put("/{id}", handler.UpdateEntry)
 	router.Delete("/{id}", handler.DeleteEntry)
 }

--- a/cmd/cloud-init-server/main.go
+++ b/cmd/cloud-init-server/main.go
@@ -83,6 +83,9 @@ func initCiRouter(router chi.Router, handler *CiHandler) {
 	// Add cloud-init endpoints to router
 	router.Get("/", handler.ListEntries)
 	router.Post("/", handler.AddEntry)
+	router.Get("/user-data", handler.GetDataByIP(UserData))
+	router.Get("/meta-data", handler.GetDataByIP(MetaData))
+	router.Get("/vendor-data", handler.GetDataByIP(VendorData))
 	router.Get("/{id}", handler.GetEntry)
 	router.Get("/{id}/user-data", handler.GetDataByMAC(UserData))
 	router.Get("/{id}/meta-data", handler.GetDataByMAC(MetaData))

--- a/internal/memstore/ciMemStore.go
+++ b/internal/memstore/ciMemStore.go
@@ -60,19 +60,11 @@ func (m MemStore) Get(name string, sm *smdclient.SMDClient) (citypes.CI, error) 
 
 	ci_merged := new(citypes.CI)
 
-	id, err := sm.IDfromMAC(name)
-	if err != nil {
-		log.Print(err)
-		id = name  // Fall back to using the given name as an ID
-	} else {
-		log.Printf("xname %s with mac %s found\n", id, name)
-	}
-
-	gl, err := sm.GroupMembership(id)
+	gl, err := sm.GroupMembership(name)
 	if err != nil {
 		log.Print(err)
 	} else if len(gl) > 0 {
-		log.Printf("xname %s is a member of these groups: %s\n", id, gl)
+		log.Printf("Node %s is a member of these groups: %s\n", name, gl)
 
 		for g := 0; g < len(gl); g++ {
 			if val, ok := m.list[gl[g]]; ok {
@@ -82,15 +74,15 @@ func (m MemStore) Get(name string, sm *smdclient.SMDClient) (citypes.CI, error) 
 			}
 		}
 	} else {
-		log.Printf("ID %s is not a member of any groups\n", id)
+		log.Printf("Node %s is not a member of any groups\n", name)
 	}
 
-	if val, ok := m.list[id]; ok {
+	if val, ok := m.list[name]; ok {
 		ci_merged.CIData.UserData = lo.Assign(ci_merged.CIData.UserData, val.CIData.UserData)
 		ci_merged.CIData.VendorData = lo.Assign(ci_merged.CIData.VendorData, val.CIData.VendorData)
 		ci_merged.CIData.MetaData = lo.Assign(ci_merged.CIData.MetaData, val.CIData.MetaData)
 	} else {
-		log.Printf("ID %s has no specific configuration\n", id)
+		log.Printf("Node %s has no specific configuration\n", name)
 	}
 
 	if len(ci_merged.CIData.UserData) == 0 &&

--- a/internal/smdclient/SMDclient.go
+++ b/internal/smdclient/SMDclient.go
@@ -35,10 +35,10 @@ type SMDClient struct {
 func NewSMDClient(baseurl string, jwtURL string) *SMDClient {
 	c := &http.Client{Timeout: 2 * time.Second}
 	return &SMDClient{
-		smdClient:   c,
-		smdBaseURL:  baseurl,
+		smdClient:     c,
+		smdBaseURL:    baseurl,
 		tokenEndpoint: jwtURL,
-		accessToken: "",
+		accessToken:   "",
 	}
 }
 
@@ -85,19 +85,13 @@ func (s *SMDClient) getSMD(ep string, smd interface{}) error {
 	return nil
 }
 
-// Helper array type
-// TODO: This probably belongs in OpenCHAMI/smd, pkg/sm/endpoints.go
-type CompEthInterfaceV2Array struct {
-	Array []*sm.CompEthInterfaceV2
-}
-
 // IDfromMAC returns the ID of the xname that has the MAC address
 func (s *SMDClient) IDfromMAC(mac string) (string, error) {
-	endpointData := new(CompEthInterfaceV2Array)
+	var ethIfaceArray []sm.CompEthInterfaceV2
 	ep := "/hsm/v2/Inventory/EthernetInterfaces/"
-	s.getSMD(ep, endpointData)
+	s.getSMD(ep, &ethIfaceArray)
 
-	for _, ep := range endpointData.Array {
+	for _, ep := range ethIfaceArray {
 		if strings.EqualFold(mac, ep.MACAddr) {
 			return ep.CompID, nil
 		}
@@ -107,11 +101,11 @@ func (s *SMDClient) IDfromMAC(mac string) (string, error) {
 
 // IDfromMAC returns the ID of the xname that has the MAC address
 func (s *SMDClient) IDfromIP(ipaddr string) (string, error) {
-	endpointData := new(CompEthInterfaceV2Array)
+	var ethIfaceArray []sm.CompEthInterfaceV2
 	ep := "/hsm/v2/Inventory/EthernetInterfaces/"
-	s.getSMD(ep, endpointData)
+	s.getSMD(ep, &ethIfaceArray)
 
-	for _, ep := range endpointData.Array {
+	for _, ep := range ethIfaceArray {
 		for _, v := range ep.IPAddrs {
 			if strings.EqualFold(ipaddr, v.IPAddr) {
 				return ep.CompID, nil

--- a/internal/smdclient/SMDclient.go
+++ b/internal/smdclient/SMDclient.go
@@ -105,6 +105,22 @@ func (s *SMDClient) IDfromMAC(mac string) (string, error) {
 	return "", errors.New("MAC " + mac + " not found for an xname in EthernetInterfaces")
 }
 
+// IDfromMAC returns the ID of the xname that has the MAC address
+func (s *SMDClient) IDfromIP(ipaddr string) (string, error) {
+	endpointData := new(CompEthInterfaceV2Array)
+	ep := "/hsm/v2/Inventory/EthernetInterfaces/"
+	s.getSMD(ep, endpointData)
+
+	for _, ep := range endpointData.Array {
+		for _, v := range ep.IPAddrs {
+			if strings.EqualFold(ipaddr, v.IPAddr) {
+				return ep.CompID, nil
+			}
+		}
+	}
+	return "", errors.New("IP address " + ipaddr + " not found for an xname in EthernetInterfaces")
+}
+
 // GroupMembership returns the group labels for the xname with the given ID
 func (s *SMDClient) GroupMembership(id string) ([]string, error) {
 	ml := new(sm.Membership)

--- a/internal/smdclient/SMDclient.go
+++ b/internal/smdclient/SMDclient.go
@@ -99,7 +99,7 @@ func (s *SMDClient) IDfromMAC(mac string) (string, error) {
 	return "", errors.New("MAC " + mac + " not found for an xname in EthernetInterfaces")
 }
 
-// IDfromMAC returns the ID of the xname that has the MAC address
+// IDfromIP returns the ID of the xname that has the IP address
 func (s *SMDClient) IDfromIP(ipaddr string) (string, error) {
 	var ethIfaceArray []sm.CompEthInterfaceV2
 	ep := "/hsm/v2/Inventory/EthernetInterfaces/"

--- a/internal/smdclient/SMDclient.go
+++ b/internal/smdclient/SMDclient.go
@@ -85,22 +85,24 @@ func (s *SMDClient) getSMD(ep string, smd interface{}) error {
 	return nil
 }
 
+// Helper array type
+// TODO: This probably belongs in OpenCHAMI/smd, pkg/sm/endpoints.go
+type CompEthInterfaceV2Array struct {
+	Array []*sm.CompEthInterfaceV2
+}
+
 // IDfromMAC returns the ID of the xname that has the MAC address
 func (s *SMDClient) IDfromMAC(mac string) (string, error) {
-	endpointData := new(sm.ComponentEndpointArray)
-	ep := "/hsm/v2/Inventory/ComponentEndpoints/"
+	endpointData := new(CompEthInterfaceV2Array)
+	ep := "/hsm/v2/Inventory/EthernetInterfaces/"
 	s.getSMD(ep, endpointData)
 
-	for _, ep := range endpointData.ComponentEndpoints {
-		id := ep.ID
-		nics := ep.RedfishSystemInfo.EthNICInfo
-		for _, v := range nics {
-			if strings.EqualFold(mac, v.MACAddress) {
-				return id, nil
-			}
+	for _, ep := range endpointData.Array {
+		if strings.EqualFold(mac, ep.MACAddr) {
+			return ep.CompID, nil
 		}
 	}
-	return "", errors.New("MAC " + mac + " not found for an xname in ComponentEndpoints")
+	return "", errors.New("MAC " + mac + " not found for an xname in EthernetInterfaces")
 }
 
 // GroupMembership returns the group labels for the xname with the given ID


### PR DESCRIPTION
This PR adds a class of endpoints (below) which do not require the querying node to specify its own MAC address for lookup purposes.
This should dramatically simplify the process of getting cloud-init data onto the node, since the server can now use the node's IP address (extracted from the HTTP request) to look up its xname from SMD.
This requires much less special effort on the node's part (i.e. logic that would need to be built into the boot image).

The new endpoints (i.e. those which perform IP-based SMD lookups) are:
- `/cloud-init[-secure]/user-data`
- `/cloud-init[-secure]/meta-data`
- `/cloud-init[-secure]/vendor-data`

The existing `/cloud-init[-secure]/<MAC address>/{user,meta,vendor}-data` endpoints continue to function normally.
