### PR TITLE
Require JWTs for write/delete operations on the "unsecured" route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- A JWKS URL is now required for operation, and will be used to validate write requests on the unsecured route.
+
 ## [0.1.1] - 2024-07-19
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,13 +19,13 @@ COPY cloud-init-server /usr/local/bin/
 ENV TOKEN_URL="http://opaal:3333/token"
 ENV SMD_URL="http://smd:27779"
 ENV LISTEN_ADDR="0.0.0.0:27777"
-ENV JWKS_URL=""
+ENV JWKS_URL="http://opaal:3333/keys"
 
 # nobody 65534:65534
 USER 65534:65534
 
 # Set up the command to start the service.
-CMD /usr/local/bin/cloud-init-server --listen ${LISTEN_ADDR} --smd-url ${SMD_URL} --token-url ${TOKEN_URL} --jwks-url ${JWKS_URL:-""}
+CMD /usr/local/bin/cloud-init-server --listen ${LISTEN_ADDR} --smd-url ${SMD_URL} --token-url ${TOKEN_URL} --jwks-url ${JWKS_URL}
 
 
 ENTRYPOINT ["/sbin/tini", "--"]


### PR DESCRIPTION
This PR implements JWT validation for sensitive (i.e. writing and deleting) operations on the "unsecured" route, i.e. the one that doesn't require auth for basic data retrieval. This requires a little bit of weirdness with multiple routers, but should generally make sense.

Resolves #14