### PR TITLE
Change API to restrict modifying metadata and add separate user-data endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,9 @@ The OpenCHAMI cloud-init server, which retrieves detailed inventory information 
 
 ## cloud-init Server Setup
 
-OpenCHAMI utilizes the cloud-init platform for post-boot configuration.
-A custom cloud-init server container is included with this quickstart Docker Compose setup, but must be populated prior to use.
+OpenCHAMI utilizes the cloud-init platform for post-boot configuration. A custom cloud-init server container is included with this quickstart Docker Compose setup, but must be populated prior to use.
 
-The cloud-init server provides two API endpoints, described in the sections below.
-Choose the appropriate option for your needs, or combine them as appropriate.
+The cloud-init server provides two API endpoints, described in the sections below. Choose the appropriate option for your needs, or combine them as appropriate.
 
 > [!NOTE]
 > This guide assumes that the cloud-init server is exposed as `foobar.openchami.cluster`.
@@ -17,51 +15,73 @@ Choose the appropriate option for your needs, or combine them as appropriate.
 ### Unprotected Data
 
 #### Setup
-The first endpoint, located at `/cloud-init/`, permits access to all stored data (and should therefore not contain configuration secrets).
-Storing data into this endpoint is accomplished via HTTP POST requests containing JSON-formatted cloud-init configuration details.
+
+User data can be injected into the cloud-init payload by making a PUT request to the `/cloud-init/{id}/user-data` endpoint. The request should contain a JSON-formatted body and can contain any arbritrary data desired.
+
 For example:
+
 ```bash
-curl 'https://foobar.openchami.cluster/cloud-init/' \
-    -X POST \
-    -d '{"name": "IDENTIFIER", "cloud-init": {
+curl 'https://foobar.openchami.cluster/cloud-init/test/user-data' \
+    -X PUT \
+    -d '{
+            "write_files": [{"content": "hello world", "path": "/etc/hello"}]
+        }
+    }}'
+```
+
+...which will create a payload that will look like the example below. Notice that the `id` gets injected into the payload as the `name` property.
+
+```json
+{
+    "name": "IDENTIFIER", 
+    "cloud-init": {
         "userdata": {
             "write_files": [{"content": "hello world", "path": "/etc/hello"}]
         },
         "metadata": {...},
-        "vendordata": {...}
-    }}'
+    }
+}
 ```
+
+**Note that data can only be injected into the `userdata` section of the payload. There is no way to add data manually to the `metadata` section.*
+
 `IDENTIFIER` can be:
+
 - A node MAC address
 - A node xname
 - An SMD group name
+
 It may be easiest to add nodes to a group for testing, and upload a cloud-init configuration for that group to this server.
 
 #### Usage
+
 Data is retrieved via HTTP GET requests to the `meta-data`, `user-data`, and `vendor-data` endpoints.
+
 For example, one could download all cloud-init data for a node/group via `curl 'https://foobar.openchami.cluster/cloud-init/<IDENTIFIER>/{meta-data,user-data,vendor-data}'`.
 
-When retrieving data, `IDENTIFIER` can also be omitted entirely (e.g. `https://foobar.openchami.cluster/cloud-init/user-data`).
-In this case, the cloud-init server will attempt to look up the relevant xname based on the request's source IP address.
+When retrieving data, `IDENTIFIER` can also be omitted entirely (e.g. `https://foobar.openchami.cluster/cloud-init/user-data`). In this case, the cloud-init server will attempt to look up the relevant xname based on the request's source IP address.
 
-Thus, the intended use case is to set nodes' cloud-init datasource URLs to `https://foobar.openchami.cluster/cloud-init/`, from which the cloud-init client will load its configuration data.
-Note that in this case, no `IDENTIFIER` is provided, so IP-based autodetection will be performed.
+Thus, the intended use case is to set nodes' cloud-init datasource URLs to `https://foobar.openchami.cluster/cloud-init/`, from which the cloud-init client will load its configuration data. Note that in this case, no `IDENTIFIER` is provided, so IP-based autodetection will be performed.
 
 ### JWT-Protected Data
 
 #### Setup
+
 The second endpoint, located at `/cloud-init-secure/`, restricts access to its cloud-init data behind a valid bearer token (i.e. a JWT).
 Storing data into this endpoint requires a valid access token, which we assume is stored in `$ACCESS_TOKEN`.
 The workflow described for unprotected data can be used, with the addition of the required authorization header, via e.g. `curl`'s `-H "Authorization: Bearer $ACCESS_TOKEN"`.
 
 #### Usage
+
 In order to access this protected data, nodes must also supply valid JWTs.
 Distribution of these tokens is out-of-scope for this repository, but may be handled via the [OpenCHAMI TPM-manager service](https://github.com/OpenCHAMI/TPM-manager).
 
 Once the JWT is known, it can be used to authenticate with the cloud-init server, via an invocation such as:
+
 ```bash
 curl 'https://foobar.openchami.cluster/cloud-init-secure/<IDENTIFIER>/{meta-data,user-data,vendor-data}' \
     --create-dirs --output '/PATH/TO/DATA-DIR/#1' \
     --header "Authorization: Bearer $ACCESS_TOKEN"
 ```
+
 cloud-init (i.e. on the node) can then be pointed at `file:///PATH/TO/DATA-DIR/` as its datasource URL.

--- a/cmd/cloud-init-server/handlers.go
+++ b/cmd/cloud-init-server/handlers.go
@@ -88,53 +88,6 @@ func (h CiHandler) AddEntry(w http.ResponseWriter, r *http.Request) {
 	render.JSON(w, r, ci.Name)
 }
 
-// AddUserEntry godoc
-// @Summary Add a new user-data entry in specified cloud-init data
-// @Description Add a new user-data entry in specified cloud-init data
-// @Accept json
-// @Produce json
-// @Param ci body CI true "User-ata entry to add to cloud-init data"
-// @Success 200 {string} string "name of the new entry"
-// @Failure 400 {string} string "bad request"
-// @Failure 500 {string} string "internal server error"
-// @Router /harbor [post]
-func (h CiHandler) AddUserEntry(w http.ResponseWriter, r *http.Request) {
-	var (
-		ci       citypes.CI
-		userdata citypes.UserData
-		body     []byte
-		err      error
-	)
-
-	// read the request body for user data
-	body, err = io.ReadAll(r.Body)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	// unmarshal only to user data and not cloud-init data
-	if err = json.Unmarshal(body, &userdata); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	// store the userdata in the cloud-init data
-	ci.CIData.UserData = userdata
-
-	// add the cloud-init data
-	err = h.store.Add(ci.Name, ci)
-	if err != nil {
-		if err == memstore.ExistingEntryErr {
-			http.Error(w, err.Error(), http.StatusNotFound)
-			return
-		}
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	render.JSON(w, r, ci.Name)
-}
-
 // GetEntry godoc
 // @Summary Get a cloud-init entry
 // @Description Get a cloud-init entry

--- a/cmd/cloud-init-server/handlers.go
+++ b/cmd/cloud-init-server/handlers.go
@@ -88,6 +88,53 @@ func (h CiHandler) AddEntry(w http.ResponseWriter, r *http.Request) {
 	render.JSON(w, r, ci.Name)
 }
 
+// AddUserEntry godoc
+// @Summary Add a new user-data entry in specified cloud-init data
+// @Description Add a new user-data entry in specified cloud-init data
+// @Accept json
+// @Produce json
+// @Param ci body CI true "User-ata entry to add to cloud-init data"
+// @Success 200 {string} string "name of the new entry"
+// @Failure 400 {string} string "bad request"
+// @Failure 500 {string} string "internal server error"
+// @Router /harbor [post]
+func (h CiHandler) AddUserEntry(w http.ResponseWriter, r *http.Request) {
+	var (
+		ci       citypes.CI
+		userdata citypes.UserData
+		body     []byte
+		err      error
+	)
+
+	// read the request body for user data
+	body, err = io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	// unmarshal only to user data and not cloud-init data
+	if err = json.Unmarshal(body, &userdata); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// store the userdata in the cloud-init data
+	ci.CIData.UserData = userdata
+
+	// add the cloud-init data
+	err = h.store.Add(ci.Name, ci)
+	if err != nil {
+		if err == memstore.ExistingEntryErr {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	render.JSON(w, r, ci.Name)
+}
+
 // GetEntry godoc
 // @Summary Get a cloud-init entry
 // @Description Get a cloud-init entry
@@ -186,6 +233,40 @@ func (h CiHandler) UpdateEntry(w http.ResponseWriter, r *http.Request) {
 
 	id := chi.URLParam(r, "id")
 
+	err = h.store.Update(id, ci)
+	if err != nil {
+		if err == memstore.NotFoundErr {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	render.JSON(w, r, id)
+}
+
+func (h CiHandler) UpdateUserEntry(w http.ResponseWriter, r *http.Request) {
+	var (
+		id       = chi.URLParam(r, "id")
+		ci       citypes.CI
+		userdata citypes.UserData
+		err      error
+	)
+
+	// read the request body for user data
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	// unmarshal only to user data and not cloud-init data
+	if err = json.Unmarshal(body, &userdata); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	// set the user-data to overwrite the existing entry
+	ci.CIData.UserData = userdata
 	err = h.store.Update(id, ci)
 	if err != nil {
 		if err == memstore.NotFoundErr {

--- a/cmd/cloud-init-server/main.go
+++ b/cmd/cloud-init-server/main.go
@@ -100,7 +100,6 @@ func initCiRouter(router chi.Router, handler *CiHandler) {
 	router.Get("/vendor-data", handler.GetDataByIP(VendorData))
 	router.Get("/{id}", handler.GetEntry)
 	router.Get("/{id}/user-data", handler.GetDataByMAC(UserData))
-	router.Post("/{id}/user-data", handler.AddUserEntry)
 	router.Put("/{id}/user-data", handler.UpdateUserEntry)
 	router.Get("/{id}/meta-data", handler.GetDataByMAC(MetaData))
 	router.Get("/{id}/vendor-data", handler.GetDataByMAC(VendorData))

--- a/cmd/cloud-init-server/main.go
+++ b/cmd/cloud-init-server/main.go
@@ -95,16 +95,18 @@ func main() {
 func initCiRouter(router chi.Router, handler *CiHandler) {
 	// Add cloud-init endpoints to router
 	router.Get("/", handler.ListEntries)
-	router.Post("/", handler.AddEntry)
 	router.Get("/user-data", handler.GetDataByIP(UserData))
 	router.Get("/meta-data", handler.GetDataByIP(MetaData))
 	router.Get("/vendor-data", handler.GetDataByIP(VendorData))
 	router.Get("/{id}", handler.GetEntry)
 	router.Get("/{id}/user-data", handler.GetDataByMAC(UserData))
+	router.Post("/{id}/user-data", handler.AddUserEntry)
+	router.Put("/{id}/user-data", handler.UpdateUserEntry)
 	router.Get("/{id}/meta-data", handler.GetDataByMAC(MetaData))
 	router.Get("/{id}/vendor-data", handler.GetDataByMAC(VendorData))
-	router.Put("/{id}", handler.UpdateEntry)
 	router.Delete("/{id}", handler.DeleteEntry)
+
+	// groups API endpoints
 	router.Post("/groups", handler.AddGroups)
 	router.Get("/groups", handler.GetGroups)
 	router.Put("/groups", handler.UpdateGroups)

--- a/pkg/citypes/models.go
+++ b/pkg/citypes/models.go
@@ -12,7 +12,13 @@ type CIData struct {
 }
 
 type (
+	// only defined for readibility
+	UserData  = map[string]any
 	GroupData = map[string]any
 )
 
-const GROUP_IDENTIFIER string = "##groups"
+// NOTE: This is just a unique constant value for access group data being stored
+// as a citypes.CI since the API's require an IDENTIFIER to access.
+//
+// NOTE: This may be removed later after creating a separate group structure.
+const GROUP_IDENTIFIER string = "%%groups%%"


### PR DESCRIPTION
This PR addresses #21 by removing the POST `/cloud-init` endpoint that allows adding an entire cloud-init payload. In addition, it adds two new endpoints for users to add or modify user-data with POST `/cloud-init/{id}/user-data` and PUT `/cloud-init/{id}/user-data` respectively. 

No endpoints were added to modify vendor data as there are no current plans to support it.  