### PR TITLE
22 groups metadata

### DIFF
--- a/cmd/cloud-init-server/main.go
+++ b/cmd/cloud-init-server/main.go
@@ -25,6 +25,7 @@ var (
 	tokenEndpoint = "http://opaal:3333/token" // jwt for smd access obtained from here
 	smdEndpoint   = "http://smd:27779"
 	jwksUrl       = "" // jwt keyserver URL for secure-route token validation
+	insecure      = false
 )
 
 func main() {
@@ -32,6 +33,7 @@ func main() {
 	flag.StringVar(&tokenEndpoint, "token-url", tokenEndpoint, "OIDC server URL (endpoint) to fetch new tokens from (for SMD access)")
 	flag.StringVar(&smdEndpoint, "smd-url", smdEndpoint, "http IP/url and port for running SMD")
 	flag.StringVar(&jwksUrl, "jwks-url", jwksUrl, "JWT keyserver URL, required to enable secure route")
+	flag.BoolVar(&insecure, "insecure", insecure, "Set to bypass TLS verification for requests")
 	flag.Parse()
 
 	// Set up JWT verification via the specified URL, if any
@@ -65,7 +67,7 @@ func main() {
 		middleware.Timeout(60*time.Second),
 		openchami_logger.OpenCHAMILogger(logger),
 	)
-	sm := smdclient.NewSMDClient(smdEndpoint, tokenEndpoint)
+	sm := smdclient.NewSMDClient(smdEndpoint, tokenEndpoint, insecure)
 
 	// Unsecured datastore and router
 	store := memstore.NewMemStore()
@@ -107,10 +109,7 @@ func initCiRouter(router chi.Router, handler *CiHandler) {
 	router.Delete("/{id}", handler.DeleteEntry)
 
 	// groups API endpoints
-	router.Post("/groups", handler.AddGroups)
 	router.Get("/groups", handler.GetGroups)
-	router.Put("/groups", handler.UpdateGroups)
-	router.Delete("/groups", handler.RemoveGroups)
 	router.Post("/groups/{id}", handler.AddGroupData)
 	router.Get("/groups/{id}", handler.GetGroupData)
 	router.Put("/groups/{id}", handler.UpdateGroupData)

--- a/cmd/cloud-init-server/store.go
+++ b/cmd/cloud-init-server/store.go
@@ -13,13 +13,8 @@ type ciStore interface {
 	Update(name string, ci citypes.CI) error
 	Remove(name string) error
 
-	// metadata groups API
-	AddGroups(groupsData citypes.GroupData) error
-	GetGroups() (citypes.GroupData, error)
-	UpdateGroups(groupsData citypes.GroupData) error
-	RemoveGroups() error
-
-	// extended group API
+	// groups API
+	GetGroups() map[string]citypes.Group
 	AddGroupData(groupName string, groupData citypes.GroupData) error
 	GetGroupData(groupName string) (citypes.GroupData, error)
 	UpdateGroupData(groupName string, groupData citypes.GroupData) error

--- a/internal/memstore/ciMemStore.go
+++ b/internal/memstore/ciMemStore.go
@@ -3,7 +3,6 @@ package memstore
 import (
 	"errors"
 	"fmt"
-	"log"
 
 	"github.com/OpenCHAMI/cloud-init/internal/smdclient"
 	"github.com/OpenCHAMI/cloud-init/pkg/citypes"
@@ -11,20 +10,22 @@ import (
 )
 
 var (
-	EmptyRequest     = errors.New("No data found in request body.")
-	NotFoundErr      = errors.New("Not found.")
-	ExistingEntryErr = errors.New("citypes.GroupData exists for this entry. Update instead.")
+	EmptyRequest = errors.New("No data found in request body.")
+	NotFoundErr  = errors.New("Not found.")
+	ExistingErr  = errors.New("citypes.GroupData exists for this entry. Update instead.")
 )
 
 type MemStore struct {
-	list map[string]citypes.CI
+	list   map[string]citypes.CI
+	groups map[string]citypes.Group
 }
 
 func NewMemStore() *MemStore {
-	list := make(map[string]citypes.CI)
-	return &MemStore{
-		list,
-	}
+	var (
+		list   = make(map[string]citypes.CI)
+		groups = make(map[string]citypes.Group)
+	)
+	return &MemStore{list, groups}
 }
 
 // Add creates new cloud-init data and stores in MemStore. If the data already
@@ -37,7 +38,7 @@ func (m MemStore) Add(name string, ci citypes.CI) error {
 		if curr.CIData.UserData == nil {
 			curr.CIData.UserData = ci.CIData.UserData
 		} else {
-			return ExistingEntryErr
+			return ExistingErr
 		}
 	}
 
@@ -45,7 +46,7 @@ func (m MemStore) Add(name string, ci citypes.CI) error {
 		if curr.CIData.MetaData == nil {
 			curr.CIData.MetaData = ci.CIData.MetaData
 		} else {
-			return ExistingEntryErr
+			return ExistingErr
 		}
 	}
 
@@ -53,7 +54,7 @@ func (m MemStore) Add(name string, ci citypes.CI) error {
 		if curr.CIData.VendorData == nil {
 			curr.CIData.VendorData = ci.CIData.VendorData
 		} else {
-			return ExistingEntryErr
+			return ExistingErr
 		}
 	}
 
@@ -62,42 +63,69 @@ func (m MemStore) Add(name string, ci citypes.CI) error {
 }
 
 // Get retrieves data stored in MemStore and returns it or an error
-func (m MemStore) Get(name string, sm *smdclient.SMDClient) (citypes.CI, error) {
+func (m MemStore) Get(id string, sm *smdclient.SMDClient) (citypes.CI, error) {
+	var (
+		groupLabels []string
+		// ci_merged  citypes.CI
+		err error
+	)
 
-	ci_merged := new(citypes.CI)
+	// fetch group name/labels from SMD
+	groupLabels, err = sm.GroupMembership(id)
+	fmt.Printf("groups: %v\n", groupLabels)
 
-	gl, err := sm.GroupMembership(name)
+	// check that we actually got something back with no errors
 	if err != nil {
-		log.Print(err)
-	} else if len(gl) > 0 {
-		log.Printf("Node %s is a member of these groups: %s\n", name, gl)
-
-		for g := 0; g < len(gl); g++ {
-			if val, ok := m.list[gl[g]]; ok {
-				ci_merged.CIData.UserData = lo.Assign(ci_merged.CIData.UserData, val.CIData.UserData)
-				ci_merged.CIData.VendorData = lo.Assign(ci_merged.CIData.VendorData, val.CIData.VendorData)
-				ci_merged.CIData.MetaData = lo.Assign(ci_merged.CIData.MetaData, val.CIData.MetaData)
+		return citypes.CI{}, err
+	} else if len(groupLabels) == 0 {
+		return citypes.CI{}, errors.New("no groups found from SMD")
+	} else {
+		// make sure we already have cloud-init data and create it if it doesn't exist
+		ci, ok := m.list[id]
+		if !ok {
+			ci = citypes.CI{
+				Name: id,
+				CIData: citypes.CIData{
+					MetaData: map[string]any{"groups": map[string]citypes.Group{}},
+				},
 			}
 		}
-	} else {
-		log.Printf("Node %s is not a member of any groups\n", name)
-	}
 
-	if val, ok := m.list[name]; ok {
-		ci_merged.CIData.UserData = lo.Assign(ci_merged.CIData.UserData, val.CIData.UserData)
-		ci_merged.CIData.VendorData = lo.Assign(ci_merged.CIData.VendorData, val.CIData.VendorData)
-		ci_merged.CIData.MetaData = lo.Assign(ci_merged.CIData.MetaData, val.CIData.MetaData)
-	} else {
-		log.Printf("Node %s has no specific configuration\n", name)
+		// add matching group data stored with groups API to metadata
+		for _, groupLabel := range groupLabels {
+			// check if the group is stored with label from SMD
+			group, ok := m.groups[groupLabel]
+			if ok {
+				// check if there's already metadata
+				if ci.CIData.MetaData != nil {
+					// check if we already have a "groups" section
+					if groups, ok := ci.CIData.MetaData["groups"].(map[string]citypes.Group); ok {
+						// found "groups" so add the new group + it's data
+						groups[groupLabel] = group
+					} else {
+						// did not find "groups", so add it with current group data
+						ci.CIData.MetaData["groups"] = map[string]citypes.Group{
+							groupLabel: group,
+						}
+					}
+				} else {
+					// no metadata found, so create it with current group data here
+					ci.CIData.MetaData = map[string]any{
+						"groups": map[string]citypes.Group{
+							groupLabel: group,
+						},
+					}
+				}
+			} else {
+				// we didn't find the group in the memstore with the label, so
+				// go on to the next one
+				fmt.Printf("failed to get '%s' from groups", groupLabel)
+				continue
+			}
+		}
+		m.list[id] = ci
 	}
-
-	if len(ci_merged.CIData.UserData) == 0 &&
-		len(ci_merged.CIData.VendorData) == 0 &&
-		len(ci_merged.CIData.MetaData) == 0 {
-		return citypes.CI{}, NotFoundErr
-	} else {
-		return *ci_merged, nil
-	}
+	return m.list[id], nil
 }
 
 // Merge combines cloud-init data from MemStore with new citypes.CI
@@ -139,146 +167,40 @@ func (m MemStore) Remove(name string) error {
 	return nil
 }
 
+func (m MemStore) GetGroups() map[string]citypes.Group {
+	return m.groups
+}
+
 /*
-AddGroup adds a new group with it's associated meta-data.
+AddGroupData adds a new group with it's associated data specified by the user.
+The group data is included in the metadata with making a request for cloud-init
+data.
 
 Example:
 
-	data := map[string]any{
-		"x3000": map[string]any {
-			"syslog_aggregator": "192.168.0.1",
-		},
-		"canary-123": map[string]any {
-			"syslog_aggregator": "127.0.0.1",
-		}
-	}
-
-AddGroup("compute", "x3000", data)
+AddGroup("x3000", data)
 
 	{
-		"name": "compute",
-		...
 		"meta-data": {
 			"groups": { // POST request should only include this data
-	        	"x3000": {
-	            	"syslog_aggregator": "192.168.0.1"
-	          	},
-	          	"canary-123": {
-	                "hello": "world"
-	          	}
-	        }
+				"x3000": {
+					"data": {
+						"syslog_aggregator": "192.168.0.1"
+					}
+				},
+				"canary-123": {
+					"data": {
+						"hello": "world"
+					}
+				}
+			}
 		}
 	}
 */
-func (m MemStore) AddGroups(newGroupData citypes.GroupData) error {
-	var (
-		node              citypes.CI
-		existingGroupData citypes.GroupData
-	)
-
-	// do nothing if no data found
-	if len(newGroupData) <= 0 {
-		return EmptyRequest
-	}
-
-	// get CI data and add groups to metadata if not exists
-	node, ok := m.list[citypes.GROUP_IDENTIFIER]
-	if ok {
-		// check if data already exists, otherwise add
-		if node.CIData.MetaData != nil {
-			return ExistingEntryErr
-		} else {
-			// check if there's already a 'groups' property
-			existingGroupData = getGroupsFromMetadata(node)
-			if existingGroupData != nil {
-				setGroupsInMetadata(node, newGroupData)
-			} else {
-				// groups already exist so return error
-				return ExistingEntryErr
-			}
-		}
-	} else {
-		// groups not found in metadata so create everything
-		node = citypes.CI{
-			CIData: citypes.CIData{
-				MetaData: citypes.GroupData{
-					"groups": newGroupData,
-				},
-			},
-		}
-	}
-	m.list[citypes.GROUP_IDENTIFIER] = node
-	return nil
-}
-
-// GetGroup returns the 'meta-data.groups' found with the provided 'name' argument.
-// Returns an error if the data is not found.
-func (m MemStore) GetGroups() (citypes.GroupData, error) {
-	var (
-		node      citypes.CI
-		groupData citypes.GroupData
-	)
-	node, ok := m.list[citypes.GROUP_IDENTIFIER]
-	if ok {
-		groupData = getGroupsFromMetadata(node)
-		if groupData != nil {
-			return groupData, nil
-		} else {
-			// no group data found so return error
-			return nil, NotFoundErr
-		}
-	}
-	// no node, component, or xname found so return error
-	return nil, NotFoundErr
-}
-
-// UpdateGroups updates the data for an existing 'meta-data.groups'. An error is
-// returned if it is not found.
-func (m MemStore) UpdateGroups(newGroupData citypes.GroupData) error {
-	var (
-		node              citypes.CI
-		existingGroupData citypes.GroupData
-	)
-
-	// do nothing if no data found
-	if len(newGroupData) <= 0 {
-		return EmptyRequest
-	}
-
-	// get CI data and update groups whether it exists or not
-	node, ok := m.list[citypes.GROUP_IDENTIFIER]
-	if ok {
-		// get existing group data and update memstore
-		existingGroupData = getGroupsFromMetadata(node)
-		if existingGroupData != nil {
-			setGroupsInMetadata(node, newGroupData)
-			m.list[citypes.GROUP_IDENTIFIER] = node
-			return nil
-		}
-		// no groups found so return not found error
-		return NotFoundErr
-	} else {
-		// no node, component, or xname found which is required to update
-		return NotFoundErr
-	}
-}
-
-func (m MemStore) RemoveGroups() error {
-	node, ok := m.list[citypes.GROUP_IDENTIFIER]
-	if ok {
-		delete(node.CIData.MetaData, citypes.GROUP_IDENTIFIER)
-		return nil
-	}
-	return NotFoundErr
-}
-
-// AddGroupData creates a new key-value for a group is it does not exists.
-//
-// NOTE: For this method, it makes sense to create the `meta-data` automatically
 func (m MemStore) AddGroupData(groupName string, newGroupData citypes.GroupData) error {
 	var (
-		node      citypes.CI
-		groupData citypes.GroupData
+	// node      citypes.CI
+	// groupData citypes.GroupData
 	)
 
 	// do nothing if no data found from the request
@@ -288,73 +210,27 @@ func (m MemStore) AddGroupData(groupName string, newGroupData citypes.GroupData)
 	}
 
 	// get CI data and check if groups IDENTIFIER exists (creates if not)
-	node, ok := m.list[citypes.GROUP_IDENTIFIER]
+	_, ok := m.groups[groupName]
 	if ok {
-		// check if metadata already exists (create if not)
-		if node.CIData.MetaData == nil {
-			node.CIData.MetaData = map[string]any{
-				"groups": map[string]any{
-					groupName: newGroupData,
-				},
-			}
-		} else {
-			// check if group already exists (create if not)
-			groupData = getGroupsFromMetadata(node)
-			if groupData == nil {
-				setGroupsInMetadata(node, citypes.GroupData{groupName: newGroupData})
-			} else {
-				// check for key in group already exists
-				_, ok = groupData[groupName]
-				if ok {
-					// fail here since we don't want to overwrite
-					return ExistingEntryErr
-				} else {
-					groupData[groupName] = newGroupData
-				}
-				// add new group data to metadata
-				node.CIData.MetaData["groups"] = groupData
-			}
-		}
+		// found group so return error
+		return ExistingErr
 	} else {
-		// no node data found so create a default one
-		node = citypes.CI{
-			CIData: citypes.CIData{
-				MetaData: citypes.GroupData{
-					"groups": map[string]any{groupName: newGroupData},
-				},
-			},
-		}
-		// update the node's name with the identifier
-		node.Name = citypes.GROUP_IDENTIFIER
+		// does not exist, so create and update
+		m.groups[groupName] = citypes.Group{"data": newGroupData}
 	}
-
-	// finally, update the CIData after making changes
-	m.list[citypes.GROUP_IDENTIFIER] = node
 	return nil
 }
 
 // GetGroupData returns the value of a specific group
 func (m MemStore) GetGroupData(groupName string) (citypes.GroupData, error) {
 	var (
-		node      citypes.CI
-		groupData citypes.GroupData
+	// node      citypes.CI
+	// groupData citypes.GroupData
 	)
 
-	// get the node info with default group identitifer
-	node, ok := m.list[citypes.GROUP_IDENTIFIER]
+	group, ok := m.groups[groupName]
 	if ok {
-		// get the groups object from the metadata
-		groupData = getGroupsFromMetadata(node)
-		if groupData != nil {
-			// finally, get the specific key from the group
-			key, ok := groupData[groupName].(map[string]any)
-			if ok {
-				return key, nil
-			}
-			return nil, NotFoundErr
-		} else {
-			return nil, NotFoundErr
-		}
+		return group["data"], nil
 	} else {
 		return nil, NotFoundErr
 	}
@@ -362,74 +238,29 @@ func (m MemStore) GetGroupData(groupName string) (citypes.GroupData, error) {
 }
 
 // UpdateGroupData is similar to AddGroupData but only works if the group exists
-func (m MemStore) UpdateGroupData(groupName string, value citypes.GroupData) error {
+func (m MemStore) UpdateGroupData(groupName string, groupData citypes.GroupData) error {
 	var (
-		node      citypes.CI
-		groupData citypes.GroupData
+	// node citypes.CI
 	)
 
 	// do nothing if no data found
-	if len(value) <= 0 {
+	if len(groupData) <= 0 {
 		return EmptyRequest
 	}
 
-	// get CI data and group if exists (creates CI data if it doesn't)
-	node, ok := m.list[citypes.GROUP_IDENTIFIER]
+	group, ok := m.groups[groupName]
 	if ok {
-		// check if metadata already exists, and create if not
-		if node.CIData.MetaData == nil {
-			node.CIData.MetaData = citypes.GroupData{
-				"groups": map[string]any{
-					groupName: value,
-				},
-			}
-		} else {
-			// check if group exists and create if there isn't
-			groupData = getGroupsFromMetadata(node)
-			if groupData == nil {
-				setGroupsInMetadata(node, citypes.GroupData{groupName: value})
-			} else {
-				// check for key in group and only create if it doesn't exist
-				_, ok = groupData[groupName]
-				if ok {
-					groupData[groupName] = value
-					return nil
-				} else {
-					return NotFoundErr
-				}
-			}
-		}
-		// finally, update the memstore
-		m.list[citypes.GROUP_IDENTIFIER] = node
-
+		group["data"] = groupData
+		m.groups[groupName] = group
 	} else {
-		// no node data found so return error
 		return NotFoundErr
 	}
-
-	return NotFoundErr
+	return nil
 }
 
 func (m MemStore) RemoveGroupData(name string) error {
-	var (
-		node                      citypes.CI
-		groupData                 citypes.GroupData
-		removeGroupDataInMetadata = func(ci citypes.CI, name string) {
-			if ci.CIData.MetaData != nil {
-				groupData = getGroupsFromMetadata(node)
-				if groupData != nil {
-					delete(groupData, name)
-				}
-			}
-		}
-	)
-
-	node, ok := m.list[citypes.GROUP_IDENTIFIER]
-	if ok {
-		removeGroupDataInMetadata(node, name)
-		return nil
-	}
-	return NotFoundErr
+	delete(m.groups, name)
+	return nil
 }
 
 func getGroupsFromMetadata(ci citypes.CI) citypes.GroupData {

--- a/pkg/citypes/models.go
+++ b/pkg/citypes/models.go
@@ -14,11 +14,6 @@ type CIData struct {
 type (
 	// only defined for readibility
 	UserData  = map[string]any
-	GroupData = map[string]any
+	Group     map[string]GroupData
+	GroupData map[string]any
 )
-
-// NOTE: This is just a unique constant value for access group data being stored
-// as a citypes.CI since the API's require an IDENTIFIER to access.
-//
-// NOTE: This may be removed later after creating a separate group structure.
-const GROUP_IDENTIFIER string = "%%groups%%"


### PR DESCRIPTION
This PR addresses #22 by generating metadata with groups when making requests to the `/cloud-init/{id}` endpoint. To test this PR,  you would need a running instance of SMD or the OpenCHAMI deployment recipes. From there, create new groups and add xnames to it (using the quickstart deployment recipe).

First, add the groups to SMD.

```bash
curl -X POST https://my.openchami.cluster:8443/hsm/v2/groups -d '{"label": "install-nginx"}' --cacert cacert.pem -H "Authorization: Bearer $ACCESS_TOKEN"
curl -X POST https://my.openchami.cluster:8443/hsm/v2/groups -d '{"label": "system-updates"}' --cacert cacert.pem -H "Authorization: Bearer $ACCESS_TOKEN"
curl -X POST https://my.openchami.cluster:8443/hsm/v2/groups -d '{"label": "monitoring"}' --cacert cacert.pem -H "Authorization: Bearer $ACCESS_TOKEN"
```

Then, add the xnames as members to each group. This example uses a `x3000c1s7b53` Node BMC, but can be replaced.

```bash
curl -X POST https://my.openchami.cluster:8443/hsm/v2/groups/install-nginx/members -d '{"id": "x3000c1s7b53"}' --cacert cacert.pem -H "Authorization: Bearer $ACCESS_TOKEN"
curl -X POST https://my.openchami.cluster:8443/hsm/v2/groups/monitoring/members -d '{"id": "x3000c1s7b53"}' --cacert cacert.pem -H "Authorization: Bearer $ACCESS_TOKEN"
curl -X POST https://my.openchami.cluster:8443/hsm/v2/groups/system-update/members -d '{"id": "x3000c1s7b53"}' --cacert cacert.pem -H "Authorization: Bearer $ACCESS_TOKEN"
```

Start the `cloud-init` server with the correct arguments. In my case, it looks something like this since I was testing locally using a bare metal build of `cloud-init`.

```bash
./cloud-init-server -listen :27780 -smd-url https://my.openchami.cluster:8443 -token-url https://my.openchami.cluster:8443/token
```

Add the groups to `cloud-int` with the data for each one.

```bash
curl -k http://127.0.0.1:27780/cloud-init/groups/install-nginx -d@install-nginx.json
curl -k http://127.0.0.1:27780/cloud-init/groups/monitoring -d@monitoring.json
curl -k http://127.0.0.1:27780/cloud-init/groups/system-update -d@system-update.json
```

The data used in the `curl` commands above is contained in three separate files below.

```json
// system-update.json
"system-update": {
  "data": {
    "tier": "base",
    "environment": "production"
  }
},
// install-nginx.json
"install-nginx": {
  "data": {
    "tier": "frontend",
    "application": "nginx"
  }
},
// monitoring.json
"monitoring": {
  "data": {
    "agent": "prometheus",
    "alerting": "enabled"
  }
}
```

Confirm the data was submitted without issues:

```bash
curl -k http://127.0.0.1:27780/cloud-init/groups           
{
        "install-nginx": {
                "data": {
                        "application": "nginx",
                        "tier": "frontend"
                }
        },
        "monitoring": {
                "data": {
                        "agent": "prometheus",
                        "alerting": "enabled"
                }
        },
        "system-update": {
                "data": {
                        "environment": "production",
                        "tier": "base"
                }
        }
}
```

Finally, make a request for `x3000c1s7b53`'s cloud-init data, which should also include the groups data just added.

```bash
curl -k http://127.0.0.1:27780/cloud-init/x3000c1s7b53
```
And you should get something that looks like this:

```json
{
  "name": "x3000c1s7b53",
  "cloud-init": {
    "userdata": null,
    "metadata": {
      "groups": {
        "install-nginx": {
          "data": {
            "application": "nginx",
            "tier": "frontend"
          }
        },
        "monitoring": {
          "data": {
            "agent": "prometheus",
            "alerting": "enabled"
          }
        },
        "system-update": {
          "data": {
            "environment": "production",
            "tier": "base"
          }
        }
      }
    },
    "vendordata": null
  }
}
```