### PR TITLE
Add `--access-token` and `--cacert` flags

### DIFF
--- a/cmd/cloud-init-server/main.go
+++ b/cmd/cloud-init-server/main.go
@@ -26,6 +26,7 @@ var (
 	smdEndpoint   = "http://smd:27779"
 	jwksUrl       = "" // jwt keyserver URL for secure-route token validation
 	insecure      = false
+	accessToken   = ""
 	store         ciStore
 )
 
@@ -34,6 +35,7 @@ func main() {
 	flag.StringVar(&tokenEndpoint, "token-url", tokenEndpoint, "OIDC server URL (endpoint) to fetch new tokens from (for SMD access)")
 	flag.StringVar(&smdEndpoint, "smd-url", smdEndpoint, "http IP/url and port for running SMD")
 	flag.StringVar(&jwksUrl, "jwks-url", jwksUrl, "JWT keyserver URL, required to enable secure route")
+	flag.StringVar(&accessToken, "access-token", accessToken, "encoded JWT access token")
 	flag.BoolVar(&insecure, "insecure", insecure, "Set to bypass TLS verification for requests")
 	flag.Parse()
 
@@ -78,7 +80,7 @@ func main() {
 		fakeSm.Summary()
 		sm = fakeSm
 	} else {
-		sm = smdclient.NewSMDClient(smdEndpoint, tokenEndpoint, insecure)
+		sm = smdclient.NewSMDClient(smdEndpoint, tokenEndpoint, accessToken, insecure)
 	}
 
 	// Unsecured datastore and router

--- a/cmd/cloud-init-server/main.go
+++ b/cmd/cloud-init-server/main.go
@@ -27,6 +27,7 @@ var (
 	jwksUrl       = "" // jwt keyserver URL for secure-route token validation
 	insecure      = false
 	accessToken   = ""
+	certPath      = ""
 	store         ciStore
 )
 
@@ -36,6 +37,7 @@ func main() {
 	flag.StringVar(&smdEndpoint, "smd-url", smdEndpoint, "http IP/url and port for running SMD")
 	flag.StringVar(&jwksUrl, "jwks-url", jwksUrl, "JWT keyserver URL, required to enable secure route")
 	flag.StringVar(&accessToken, "access-token", accessToken, "encoded JWT access token")
+	flag.StringVar(&certPath, "cacert", certPath, "Path to CA cert. (defaults to system CAs)")
 	flag.BoolVar(&insecure, "insecure", insecure, "Set to bypass TLS verification for requests")
 	flag.Parse()
 
@@ -80,7 +82,7 @@ func main() {
 		fakeSm.Summary()
 		sm = fakeSm
 	} else {
-		sm = smdclient.NewSMDClient(smdEndpoint, tokenEndpoint, accessToken, insecure)
+		sm = smdclient.NewSMDClient(smdEndpoint, tokenEndpoint, accessToken, certPath, insecure)
 	}
 
 	// Unsecured datastore and router

--- a/internal/smdclient/SMDclient.go
+++ b/internal/smdclient/SMDclient.go
@@ -42,7 +42,7 @@ type SMDClient struct {
 
 // NewSMDClient creates a new SMDClient which connects to the SMD server at baseurl
 // and uses the provided JWT server for authentication
-func NewSMDClient(baseurl string, jwtURL string, insecure bool) *SMDClient {
+func NewSMDClient(baseurl string, jwtURL string, accessToken string, insecure bool) *SMDClient {
 	c := &http.Client{Timeout: 2 * time.Second}
 	if insecure {
 		c.Transport = &http.Transport{
@@ -55,7 +55,7 @@ func NewSMDClient(baseurl string, jwtURL string, insecure bool) *SMDClient {
 		smdClient:     c,
 		smdBaseURL:    baseurl,
 		tokenEndpoint: jwtURL,
-		accessToken:   "",
+		accessToken:   accessToken,
 	}
 }
 


### PR DESCRIPTION
This PR adds the flags mentioned in the title similarly to the other OpenCHAMI services.