### PR TITLE
updating goreleaser-action to v6 in workflow

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -42,7 +42,7 @@ jobs:
           echo "BUILD_USER=$(whoami)" >> $GITHUB_ENV
           echo "CGO_ENABLED=0" >> $GITHUB_ENV
       - name: Release with goreleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
Hoping this fixes this error in the release action:
```
release failed after 0s                  error=only configurations files on  version: 1  are supported, yours is  version: 2 , please update your configuration
```