### PR TITLE
docs: add missing payload data to POST/PUT openapi docs

### DIFF
--- a/cmd/cloud-init-server/group_handlers.go
+++ b/cmd/cloud-init-server/group_handlers.go
@@ -127,11 +127,12 @@ func (h CiHandler) GetGroupHandler(w http.ResponseWriter, r *http.Request) {
 //	@Description	any existing content.
 //	@Tags			admin,groups
 //	@Accept			json
-//	@Success		201		{object}	nil
-//	@Failure		422		{object}	nil
-//	@Failure		500		{object}	nil
-//	@Header			201		{string}	Location	"/groups/{name}"
-//	@Param			name	path		string		true	"Group name"
+//	@Success		201			{object}	nil
+//	@Failure		422			{object}	nil
+//	@Failure		500			{object}	nil
+//	@Header			201			{string}	Location			"/groups/{name}"
+//	@Param			name		path		string				true	"Group name"
+//	@Param			group_data	body		cistore.GroupData	true	"Group data"
 //	@Router			/cloud-init/admin/groups/{name} [put]
 func (h CiHandler) UpdateGroupHandler(w http.ResponseWriter, r *http.Request) {
 	var (

--- a/cmd/cloud-init-server/handlers.go
+++ b/cmd/cloud-init-server/handlers.go
@@ -71,9 +71,10 @@ func DocsHandler(w http.ResponseWriter, r *http.Request) {
 //	@Description	Set default meta-data values for cluster.
 //	@Tags			admin,cluster-defaults
 //	@Accept			json
-//	@Success		201	{object}	nil
-//	@Failure		400	{object}	nil
-//	@Failure		500	{object}	nil
+//	@Success		201		{object}	nil
+//	@Failure		400		{object}	nil
+//	@Failure		500		{object}	nil
+//	@Param			data	body		cistore.ClusterDefaults	true	"Cluster defaults data"
 //	@Router			/cloud-init/admin/cluster-defaults [post]
 func SetClusterDataHandler(store cistore.Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -141,10 +142,11 @@ func GetClusterDataHandler(store cistore.Store) http.HandlerFunc {
 //	@Description	Set meta-data for a specific node ID, overwriting relevant group meta-data.
 //	@Tags			admin,instance-data
 //	@Accept			json
-//	@Success		201	{object}	nil
-//	@Failure		400	{object}	nil
-//	@Failure		500	{object}	nil
-//	@Param			id	path		string	true	"Node ID"
+//	@Success		201				{object}	nil
+//	@Failure		400				{object}	nil
+//	@Failure		500				{object}	nil
+//	@Param			id				path		string							true	"Node ID"
+//	@Param			instance-info	body		cistore.OpenCHAMIInstanceInfo	true	"Instance info data"
 //	@Router			/cloud-init/admin/instance-info/{id} [put]
 func InstanceInfoHandler(sm smdclient.SMDClientInterface, store cistore.Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -52,6 +52,17 @@ const docTemplate = `{
                     "cluster-defaults"
                 ],
                 "summary": "Set cluster defaults",
+                "parameters": [
+                    {
+                        "description": "Cluster defaults data",
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/cistore.ClusterDefaults"
+                        }
+                    }
+                ],
                 "responses": {
                     "201": {
                         "description": "Created"
@@ -207,6 +218,15 @@ const docTemplate = `{
                         "name": "name",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "description": "Group data",
+                        "name": "group_data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/cistore.GroupData"
+                        }
                     }
                 ],
                 "responses": {
@@ -368,6 +388,15 @@ const docTemplate = `{
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "description": "Instance info data",
+                        "name": "instance-info",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/cistore.OpenCHAMIInstanceInfo"
+                        }
                     }
                 ],
                 "responses": {
@@ -689,6 +718,54 @@ const docTemplate = `{
                 "name": {
                     "type": "string",
                     "example": "compute"
+                }
+            }
+        },
+        "cistore.OpenCHAMIInstanceInfo": {
+            "type": "object",
+            "properties": {
+                "availability-zone": {
+                    "type": "string"
+                },
+                "cloud-init-base-url": {
+                    "type": "string"
+                },
+                "cloud-provider": {
+                    "type": "string"
+                },
+                "cluster-name": {
+                    "type": "string",
+                    "example": "demo"
+                },
+                "hostname": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "x3000c1b1n1"
+                },
+                "instance-id": {
+                    "type": "string"
+                },
+                "instance-type": {
+                    "type": "string"
+                },
+                "local-hostname": {
+                    "type": "string",
+                    "example": "compute-1"
+                },
+                "public-keys": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMLtQNuzGcMDatF+YVMMkuxbX2c5v2OxWftBhEVfFb+U user1@demo-head",
+                        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB4vVRvkzmGE5PyWX2fuzJEgEfET4PRLHXCnD1uFZ8ZL user2@demo-head"
+                    ]
+                },
+                "region": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -44,6 +44,17 @@
                     "cluster-defaults"
                 ],
                 "summary": "Set cluster defaults",
+                "parameters": [
+                    {
+                        "description": "Cluster defaults data",
+                        "name": "data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/cistore.ClusterDefaults"
+                        }
+                    }
+                ],
                 "responses": {
                     "201": {
                         "description": "Created"
@@ -199,6 +210,15 @@
                         "name": "name",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "description": "Group data",
+                        "name": "group_data",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/cistore.GroupData"
+                        }
                     }
                 ],
                 "responses": {
@@ -360,6 +380,15 @@
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "description": "Instance info data",
+                        "name": "instance-info",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/cistore.OpenCHAMIInstanceInfo"
+                        }
                     }
                 ],
                 "responses": {
@@ -681,6 +710,54 @@
                 "name": {
                     "type": "string",
                     "example": "compute"
+                }
+            }
+        },
+        "cistore.OpenCHAMIInstanceInfo": {
+            "type": "object",
+            "properties": {
+                "availability-zone": {
+                    "type": "string"
+                },
+                "cloud-init-base-url": {
+                    "type": "string"
+                },
+                "cloud-provider": {
+                    "type": "string"
+                },
+                "cluster-name": {
+                    "type": "string",
+                    "example": "demo"
+                },
+                "hostname": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "x3000c1b1n1"
+                },
+                "instance-id": {
+                    "type": "string"
+                },
+                "instance-type": {
+                    "type": "string"
+                },
+                "local-hostname": {
+                    "type": "string",
+                    "example": "compute-1"
+                },
+                "public-keys": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMLtQNuzGcMDatF+YVMMkuxbX2c5v2OxWftBhEVfFb+U user1@demo-head",
+                        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB4vVRvkzmGE5PyWX2fuzJEgEfET4PRLHXCnD1uFZ8ZL user2@demo-head"
+                    ]
+                },
+                "region": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -60,6 +60,41 @@ definitions:
         example: compute
         type: string
     type: object
+  cistore.OpenCHAMIInstanceInfo:
+    properties:
+      availability-zone:
+        type: string
+      cloud-init-base-url:
+        type: string
+      cloud-provider:
+        type: string
+      cluster-name:
+        example: demo
+        type: string
+      hostname:
+        type: string
+      id:
+        example: x3000c1b1n1
+        type: string
+      instance-id:
+        type: string
+      instance-type:
+        type: string
+      local-hostname:
+        example: compute-1
+        type: string
+      public-keys:
+        example:
+        - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMLtQNuzGcMDatF+YVMMkuxbX2c5v2OxWftBhEVfFb+U
+          user1@demo-head
+        - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB4vVRvkzmGE5PyWX2fuzJEgEfET4PRLHXCnD1uFZ8ZL
+          user2@demo-head
+        items:
+          type: string
+        type: array
+      region:
+        type: string
+    type: object
   main.Group:
     additionalProperties: true
     type: object
@@ -213,6 +248,13 @@ paths:
       consumes:
       - application/json
       description: Set default meta-data values for cluster.
+      parameters:
+      - description: Cluster defaults data
+        in: body
+        name: data
+        required: true
+        schema:
+          $ref: '#/definitions/cistore.ClusterDefaults'
       responses:
         "201":
           description: Created
@@ -341,6 +383,12 @@ paths:
         name: name
         required: true
         type: string
+      - description: Group data
+        in: body
+        name: group_data
+        required: true
+        schema:
+          $ref: '#/definitions/cistore.GroupData'
       responses:
         "201":
           description: Created
@@ -469,6 +517,12 @@ paths:
         name: id
         required: true
         type: string
+      - description: Instance info data
+        in: body
+        name: instance-info
+        required: true
+        schema:
+          $ref: '#/definitions/cistore.OpenCHAMIInstanceInfo'
       responses:
         "201":
           description: Created


### PR DESCRIPTION
JSON payload data was missing from some of the PUT/POST endpoints in the OpenAPI documentation. This PR adds it in.