### PR TITLE
fix(groups): return JSON when requesting specific group

### DIFF
--- a/cmd/cloud-init-server/group_handlers.go
+++ b/cmd/cloud-init-server/group_handlers.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/OpenCHAMI/cloud-init/pkg/cistore"
 	"github.com/go-chi/chi/v5"
-	yaml "gopkg.in/yaml.v2"
 )
 
 // GetGroups godoc
@@ -107,7 +106,7 @@ func (h CiHandler) GetGroupHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	bytes, err = yaml.Marshal(data)
+	bytes, err = json.Marshal(data)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
fixes #56 

In the current state, requesting a specific group's data from `/cloud-init/admin/groups/{name}` returns a YAML document whose cloud-init file content is a list of integers representing the file's bytes. For example:

```yaml
description: ""
data:
  foo: bar 
file:
  content:
  - 35
  - 35
  [...snip...]
  - 101 
  - 10 name: "" encoding: base64
```

Instead of this, it would be more consistent and easier to parse if this endpoint returned JSON with a proper base64-encoded config. For example, with this PR:

a JSON document with a proper base64-encoded config is returned:
```json
{
  "file": { 
    "content": "IyM[...snip...]ZQo=",
    "encoding": "base64",
    "filename": ""
  },
  "meta-data": { 
    "foo": "bar"
  },
  "name": "tester"
} 
```