### PR TITLE
fix: correct UnmarshalJSON and add MarshalJSON for CloudConfigFile

### DIFF
--- a/pkg/cistore/models.go
+++ b/pkg/cistore/models.go
@@ -72,9 +72,14 @@ type CloudConfigFile struct {
 
 // Custom unmarshaler for CloudConfigFile
 func (f *CloudConfigFile) UnmarshalJSON(data []byte) error {
-	// Use temporary struct so json.Unmarshal does not recurse indefinitely.
-	// Also to convert Content from bytes to string so json.Unmarshal
-	// doesn't try to base64 decode the bytes.
+	// Use an auxiliary struct so that:
+	//
+	// 1. json.Unmarshal doesn't recurse forever and overflow the stack.
+	// 2. json.Unmarshal doesn't try to base64-decode "content" in the data
+	//    before assigning the bytes to f.Content. Content is unmarshalled
+	//    as a string instead of bytes in order to prevent this. After
+	//    unmarshalling, the string is converted back to bytes and assigned
+	//    to f.Content.
 	type Alias CloudConfigFile
 	aux := &struct {
 		Content string `json:"content"`
@@ -96,6 +101,12 @@ func (f CloudConfigFile) MarshalJSON() ([]byte, error) {
 	// Use temporary struct to marshal so json.Marshal doesn't recurse
 	// indefinitely. Also to convert Content from bytes to string so
 	// json.Marshal doesn't try to base64 encode the bytes.
+	// Use an auxiliary struct so that:
+	//
+	// 1. json.Marshal doesn't recurse forever and overflow the stack.
+	// 2. json.Marshal doesn't try to base64-encode f.Content. f.Content is
+	//    converted from bytes to a string and then assigned to aux.Content
+	//    to prevent this. Then, aux gets marshalled instead of f.
 	type Alias CloudConfigFile
 	aux := &struct {
 		Content string `json:"content"`

--- a/pkg/cistore/models_test.go
+++ b/pkg/cistore/models_test.go
@@ -59,10 +59,12 @@ func TestCloudConfigFile_MarshalJSON_Plain(t *testing.T) {
 }
 
 func TestCloudConfigFile_MarshalJSON_Base64(t *testing.T) {
+	originalConfig := "#cloud-config\nusers:\n  - name: test"
+	b64Config := base64.StdEncoding.EncodeToString([]byte(originalConfig))
 	f := CloudConfigFile{
 		Name:     "encodedconfig.yaml",
 		Encoding: "base64",
-		Content:  []byte("#cloud-config\nusers:\n  - name: test"),
+		Content:  []byte(b64Config),
 	}
 
 	data, err := json.Marshal(f)
@@ -73,5 +75,5 @@ func TestCloudConfigFile_MarshalJSON_Base64(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "encodedconfig.yaml", out["filename"])
 	assert.Equal(t, "base64", out["encoding"])
-	assert.Equal(t, "#cloud-config\nusers:\n  - name: test", out["content"])
+	assert.Equal(t, b64Config, out["content"])
 }

--- a/pkg/cistore/models_test.go
+++ b/pkg/cistore/models_test.go
@@ -1,0 +1,77 @@
+package cistore
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCloudConfigFile_UnmarshalJSON_Plain(t *testing.T) {
+	jsonData := []byte(`{
+        "filename": "myconfig.yaml",
+        "encoding": "plain",
+        "content": "#cloud-config\nusers:\n  - name: test"
+    }`)
+
+	var f CloudConfigFile
+	err := json.Unmarshal(jsonData, &f)
+	assert.NoError(t, err)
+	assert.Equal(t, "myconfig.yaml", f.Name)
+	assert.Equal(t, "plain", f.Encoding)
+	assert.Equal(t, []byte("#cloud-config\nusers:\n  - name: test"), f.Content)
+}
+
+func TestCloudConfigFile_UnmarshalJSON_Base64(t *testing.T) {
+	encodedContent := base64.StdEncoding.EncodeToString([]byte("#cloud-config\nusers:\n  - name: test"))
+	jsonData := []byte(`{
+        "filename": "myconfig.yaml",
+        "encoding": "base64",
+        "content": "` + encodedContent + `"
+    }`)
+
+	var f CloudConfigFile
+	err := json.Unmarshal(jsonData, &f)
+	assert.NoError(t, err, "Unmarshal should succeed for base64 content")
+	assert.Equal(t, "myconfig.yaml", f.Name)
+	assert.Equal(t, "base64", f.Encoding)
+	// Even though "encoding" is "base64" in JSON, the unmarshaler does NOT auto-decode.
+	assert.Equal(t, []byte(encodedContent), f.Content)
+}
+
+func TestCloudConfigFile_MarshalJSON_Plain(t *testing.T) {
+	f := CloudConfigFile{
+		Name:     "plainconfig.yaml",
+		Encoding: "plain",
+		Content:  []byte("#cloud-config\nusers:\n  - name: test"),
+	}
+
+	data, err := json.Marshal(f)
+	assert.NoError(t, err)
+
+	var out map[string]interface{}
+	err = json.Unmarshal(data, &out)
+	assert.NoError(t, err)
+	assert.Equal(t, "plainconfig.yaml", out["filename"])
+	assert.Equal(t, "plain", out["encoding"])
+	assert.Equal(t, "#cloud-config\nusers:\n  - name: test", out["content"])
+}
+
+func TestCloudConfigFile_MarshalJSON_Base64(t *testing.T) {
+	f := CloudConfigFile{
+		Name:     "encodedconfig.yaml",
+		Encoding: "base64",
+		Content:  []byte("#cloud-config\nusers:\n  - name: test"),
+	}
+
+	data, err := json.Marshal(f)
+	assert.NoError(t, err)
+
+	var out map[string]interface{}
+	err = json.Unmarshal(data, &out)
+	assert.NoError(t, err)
+	assert.Equal(t, "encodedconfig.yaml", out["filename"])
+	assert.Equal(t, "base64", out["encoding"])
+	assert.Equal(t, "#cloud-config\nusers:\n  - name: test", out["content"])
+}


### PR DESCRIPTION
Closes #65 

Turns out, `UnmarshalJSON()` needed to be revised and a `MarshalJSON()` needed to be added for `CloudConfigFile`. Base64 encoding/decoding caused by `json.Marshal()`/`json.Unmarshal()` was causing mismatches between `CloudConfigFile.Encoding` and the actual encoding of `CloudConfigFile.Content`.

For `UnmarshalJSON()`, continue unmarshalling `Content` into a string, but don't try to base64 decode into the struct. `Encoding` will let the reader know if they need to decode it or not.

For `MarshalJSON()`, use the auxiliary struct like `UnmarshalJSON()` does to convert the bytes to a string so that `json.Marshal()` doesn't try to base64-encode the bytes.