### PR TITLE
feat: add version endpoint and version information handler

### DIFF
--- a/cmd/cloud-init-server/main.go
+++ b/cmd/cloud-init-server/main.go
@@ -194,6 +194,7 @@ func main() {
 func initCiClientRouter(router chi.Router, handler *CiHandler, wgInterfaceManager *wgtunnel.InterfaceManager) {
 	// Add cloud-init endpoints to router
 	router.Get("/openapi.json", DocsHandler)
+	router.Get("/version", VersionHandler)
 	router.With(wireGuardMiddleware).Get("/user-data", UserDataHandler)
 	router.With(wireGuardMiddleware).Get("/meta-data", MetaDataHandler(handler.sm, handler.store))
 	router.With(wireGuardMiddleware).Get("/vendor-data", VendorDataHandler(handler.sm, handler.store))

--- a/cmd/cloud-init-server/version.go
+++ b/cmd/cloud-init-server/version.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+)
+
+// GitCommit stores the latest Git commit hash.
+// Set via -ldflags "-X main.GitCommit=$(git rev-parse HEAD)"
+var GitCommit string
+
+// BuildTime stores the build timestamp in UTC.
+// Set via -ldflags "-X main.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+var BuildTime string
+
+// Version indicates the version of the binary, such as a release number or semantic version.
+// Set via -ldflags "-X main.Version=v1.0.0"
+var Version string
+
+// GitBranch holds the name of the Git branch from which the build was created.
+// Set via -ldflags "-X main.GitBranch=$(git rev-parse --abbrev-ref HEAD)"
+var GitBranch string
+
+// GitTag represents the most recent Git tag at build time, if any.
+// Set via -ldflags "-X main.GitTag=$(git describe --tags --abbrev=0)"
+var GitTag string
+
+// GitState indicates whether the working directory was "clean" or "dirty" (i.e., with uncommitted changes).
+// Set via -ldflags "-X main.GitState=$(if git diff-index --quiet HEAD --; then echo 'clean'; else echo 'dirty'; fi)"
+var GitState string
+
+// BuildHost stores the hostname of the machine where the binary was built.
+// Set via -ldflags "-X main.BuildHost=$(hostname)"
+var BuildHost string
+
+// GoVersion captures the Go version used to build the binary.
+// Typically, this can be obtained automatically with runtime.Version(), but you can set it manually.
+// Set via -ldflags "-X main.GoVersion=$(go version | awk '{print $3}')"
+var GoVersion string
+
+// BuildUser is the username of the person or system that initiated the build process.
+// Set via -ldflags "-X main.BuildUser=$(whoami)"
+var BuildUser string
+
+var (
+	startTime   time.Time
+	runtimeHost string
+	processName string
+)
+
+// PrintVersionInfo outputs all versioning information for troubleshooting or version checks.
+func PrintVersionInfo() {
+	fmt.Printf("Version: %s\n", Version)
+	fmt.Printf("Git Commit: %s\n", GitCommit)
+	fmt.Printf("Build Time: %s\n", BuildTime)
+	fmt.Printf("Git Branch: %s\n", GitBranch)
+	fmt.Printf("Git Tag: %s\n", GitTag)
+	fmt.Printf("Git State: %s\n", GitState)
+	fmt.Printf("Build Host: %s\n", BuildHost)
+	fmt.Printf("Go Version: %s\n", GoVersion)
+	fmt.Printf("Build User: %s\n", BuildUser)
+}
+
+func init() {
+	startTime = time.Now()
+	hostname, err := os.Hostname()
+	if err == nil {
+		runtimeHost = hostname
+	} else {
+		runtimeHost = "unknown"
+	}
+	processName = filepath.Base(os.Args[0])
+}
+
+func VersionInfo() string {
+	return fmt.Sprintf("Version: %s, Git Commit: %s, Build Time: %s, Git Branch: %s, Git Tag: %s, Git State: %s, Build Host: %s, Go Version: %s, Build User: %s",
+		Version, GitCommit, BuildTime, GitBranch, GitTag, GitState, BuildHost, GoVersion, BuildUser)
+}
+
+func VersionHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	info := VersionInfo()
+	uptime := time.Since(startTime).String()
+	memstats := &runtime.MemStats{}
+	runtime.ReadMemStats(memstats)
+
+	response := struct {
+		ProcessName    string `json:"process_name"`
+		BuildInfo      string `json:"build_info"`
+		Uptime         string `json:"uptime"`
+		RuntimeHost    string `json:"runtime_host"`
+		BytesAllocated uint64 `json:"bytes_allocated"`
+	}{
+		ProcessName:    processName,
+		BuildInfo:      info,
+		Uptime:         uptime,
+		RuntimeHost:    runtimeHost,
+		BytesAllocated: memstats.HeapAlloc,
+	}
+
+	json.NewEncoder(w).Encode(response)
+}


### PR DESCRIPTION
This pull request introduces a new `/version` endpoint to the cloud-init server and implements a detailed versioning and build information system. The changes include adding a handler to serve version information and defining variables to capture build metadata, which can be set during the build process using `-ldflags`. 

### New `/version` endpoint:

* Added a new route `/version` to the cloud-init server router in `cmd/cloud-init-server/main.go`. This route is handled by the newly introduced `VersionHandler`.

### Versioning and build metadata:

* Implemented a new file `cmd/cloud-init-server/version.go` to define variables for build metadata (e.g., `Version`, `GitCommit`, `BuildTime`, etc.) and provide functions to expose this information. These variables can be set via `-ldflags` during the build process.
* Introduced the `VersionHandler` function to return build and runtime information as a JSON response. This includes details such as process name, uptime, runtime host, and memory usage.
* Added utility functions like `PrintVersionInfo` for logging version details and `VersionInfo` for formatting build metadata into a string.