### PR TITLE
fix: get correct array length for b64 inclue files

### DIFF
--- a/cmd/cloud-init-server/base64_decode_test.go
+++ b/cmd/cloud-init-server/base64_decode_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/OpenCHAMI/cloud-init/internal/memstore"
+	"github.com/OpenCHAMI/cloud-init/pkg/cistore"
+)
+
+// TestBase64Decoding tests that base64 decoding doesn't produce trailing NUL bytes
+func TestBase64Decoding(t *testing.T) {
+	// Create test content
+	originalContent := `#cloud-config
+packages:
+  - wget
+  - curl
+write_files:
+  - path: /etc/test.conf
+    content: |
+      test configuration file
+      with multiple lines
+    permissions: '0600'`
+
+	// Encode it to base64
+	encodedContent := base64.StdEncoding.EncodeToString([]byte(originalContent))
+
+	// Create test group data with base64 encoded content
+	store := memstore.NewMemStore()
+	groupData := cistore.GroupData{
+		Name:        "test-base64",
+		Description: "Test group for base64 decoding",
+		File: cistore.CloudConfigFile{
+			Content:  []byte(encodedContent),
+			Encoding: "base64",
+		},
+	}
+
+	err := store.AddGroupData("test-base64", groupData)
+	if err != nil {
+		t.Fatalf("Failed to add group data: %v", err)
+	}
+
+	// Retrieve and decode (simulating what the handler does)
+	retrievedData, err := store.GetGroupData("test-base64")
+	if err != nil {
+		t.Fatalf("Failed to retrieve group data: %v", err)
+	}
+
+	// Perform the base64 decoding using our new approach
+	if retrievedData.File.Encoding == "base64" {
+		decodedContent, err := base64.StdEncoding.DecodeString(string(retrievedData.File.Content))
+		if err != nil {
+			t.Fatalf("Failed to base64-decode content: %v", err)
+		}
+		retrievedData.File.Content = decodedContent
+		retrievedData.File.Encoding = "plain"
+	}
+
+	// Verify the decoded content
+	decodedStr := string(retrievedData.File.Content)
+
+	// Check that content matches original
+	if decodedStr != originalContent {
+		t.Errorf("Decoded content doesn't match original.\nExpected:\n%s\nGot:\n%s", originalContent, decodedStr)
+	}
+
+	// Check for trailing NUL bytes (the main issue from PR #86)
+	if strings.Contains(decodedStr, "\x00") {
+		t.Error("Decoded content contains NUL bytes (\\x00)")
+	}
+
+	// Check for the specific pattern mentioned in the PR
+	if strings.HasSuffix(decodedStr, "\x00") {
+		t.Error("Decoded content has trailing NUL bytes")
+	}
+
+	// Verify length is exactly what we expect
+	if len(decodedStr) != len(originalContent) {
+		t.Errorf("Decoded content length mismatch. Expected %d, got %d", len(originalContent), len(decodedStr))
+	}
+
+	t.Logf("Successfully decoded %d bytes without NUL bytes", len(decodedStr))
+}
+
+// TestBase64DecodingWithVariousContent tests decoding with different content sizes
+func TestBase64DecodingWithVariousContent(t *testing.T) {
+	testCases := []struct {
+		name    string
+		content string
+	}{
+		{
+			name:    "short content",
+			content: "test",
+		},
+		{
+			name:    "medium content",
+			content: strings.Repeat("Hello, World! ", 100),
+		},
+		{
+			name:    "long content",
+			content: strings.Repeat("This is a longer test string with various characters: !@#$%^&*()_+-={}[]|\\:;\"'<>?,./\n", 50),
+		},
+		{
+			name:    "content with newlines",
+			content: "#cloud-config\npackages:\n  - vim\n  - git\nruncmd:\n  - echo 'Hello World'\n",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Encode to base64
+			encodedContent := base64.StdEncoding.EncodeToString([]byte(tc.content))
+
+			// Decode using our new approach
+			decodedContent, err := base64.StdEncoding.DecodeString(encodedContent)
+			if err != nil {
+				t.Fatalf("Failed to decode base64 content: %v", err)
+			}
+
+			decodedStr := string(decodedContent)
+
+			// Verify content matches
+			if decodedStr != tc.content {
+				t.Errorf("Content mismatch for %s", tc.name)
+			}
+
+			// Check for NUL bytes
+			if strings.Contains(decodedStr, "\x00") {
+				t.Errorf("Content contains NUL bytes for %s", tc.name)
+			}
+
+			// Check length
+			if len(decodedStr) != len(tc.content) {
+				t.Errorf("Length mismatch for %s. Expected %d, got %d", tc.name, len(tc.content), len(decodedStr))
+			}
+		})
+	}
+}

--- a/cmd/cloud-init-server/userdata_handlers.go
+++ b/cmd/cloud-init-server/userdata_handlers.go
@@ -72,7 +72,7 @@ func GroupUserDataHandler(smd smdclient.SMDClientInterface, store cistore.Store)
 
 		// Make sure cloud-config content is plaintext before returning
 		if data.File.Encoding == "base64" {
-			contentBytes := make([]byte, base64.StdEncoding.EncodedLen(len(data.File.Content)))
+			contentBytes := make([]byte, base64.StdEncoding.DecodedLen(len(data.File.Content)))
 			if n, err := base64.StdEncoding.Decode(contentBytes, data.File.Content); err != nil {
 				newErr := fmt.Errorf("failed to base64-decode cloud-config (read %d bytes): %w", n, err)
 				http.Error(w, newErr.Error(), http.StatusInternalServerError)

--- a/cmd/cloud-init-server/userdata_handlers.go
+++ b/cmd/cloud-init-server/userdata_handlers.go
@@ -72,13 +72,13 @@ func GroupUserDataHandler(smd smdclient.SMDClientInterface, store cistore.Store)
 
 		// Make sure cloud-config content is plaintext before returning
 		if data.File.Encoding == "base64" {
-			contentBytes := make([]byte, base64.StdEncoding.DecodedLen(len(data.File.Content)))
-			if n, err := base64.StdEncoding.Decode(contentBytes, data.File.Content); err != nil {
-				newErr := fmt.Errorf("failed to base64-decode cloud-config (read %d bytes): %w", n, err)
+			decodedContent, err := base64.StdEncoding.DecodeString(string(data.File.Content))
+			if err != nil {
+				newErr := fmt.Errorf("failed to base64-decode cloud-config: %w", err)
 				http.Error(w, newErr.Error(), http.StatusInternalServerError)
 				return
 			}
-			data.File.Content = contentBytes
+			data.File.Content = decodedContent
 			data.File.Encoding = "plain"
 		}
 


### PR DESCRIPTION
When serving a file with stored base64 content in GroupUserDataHandler, use the decoded base64 length when building the decoded content placeholder slice.

Previously, this used the encoded length, which was backwards, and resulted in a bunch of NUL in the content.

This aligns with the example at https://pkg.go.dev/encoding/base64#Encoding.Decode

---

If you follow https://github.com/OpenCHAMI/cloud-init/blob/0da180c100f6298d52751988dbf9fab5f3fa6f5a/demo/Demo.md#complex-base64-example you will hit issues trying to retrieve the file.

In cloud-init:

```
2025-09-24 23:29:06,901 - util.py[DEBUG]: Attempting to load yaml from string of length 6764 with allowed root types (<class 'dict'>,)
2025-09-24 23:29:06,901 - util.py[WARNING]: Failed loading yaml blob. unacceptable character #x0000: special characters are not allowed
  in "<unicode string>", position 3802
```

When curl-ing it:
```
# curl -sv http://192.168.8.68/compute.yaml
*   Trying 192.168.8.68:80...
* Connected to 192.168.8.68 (192.168.8.68) port 80 (#0)
> GET /compute.yaml HTTP/1.1
> Host: 192.168.8.68
> User-Agent: curl/7.76.1
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Date: Wed, 24 Sep 2025 23:42:47 GMT
< Content-Type: text/plain; charset=utf-8
< Transfer-Encoding: chunked
< 
* Failure writing output to destination
* Failed reading the chunked-encoded stream
* Closing connection 0
```
If you `curl -o /tmp/compute.yaml` the same, you'll see something like:

```
# cat -v /tmp/compute.yaml | tail -2
  permissions: '0600'
^@^@^@^@^@^@^@^@^@
```