### PR TITLE
fix(SMDclient): check length's array

### DIFF
--- a/internal/smdclient/SMDclient.go
+++ b/internal/smdclient/SMDclient.go
@@ -249,8 +249,10 @@ func (s *SMDClient) PopulateNodes() {
 				// This is a new interface.  Add it to the map
 				newInterface := NodeInterface{
 					MAC:  ep.MACAddr,
-					IP:   ep.IPAddrs[0].IPAddr,
 					Desc: ep.Desc,
+				}
+				if len(ep.IPAddrs) > 0 {
+					newInterface.IP = ep.IPAddrs[0].IPAddr
 				}
 				existingNode.Interfaces = append(existingNode.Interfaces, newInterface)
 				s.nodes[ep.CompID] = existingNode


### PR DESCRIPTION
# fix(SMDclient): check length's array

avoid indexing an empty array

see https://github.com/OpenCHAMI/cloud-init/issues/85
