### PR TITLE
fix: GetGroupHandler: return 404 if group not found

### DIFF
--- a/cmd/cloud-init-server/group_handlers.go
+++ b/cmd/cloud-init-server/group_handlers.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"net/http"
+	"reflect"
 
 	"github.com/OpenCHAMI/cloud-init/pkg/cistore"
 	"github.com/go-chi/chi/v5"
@@ -89,6 +90,7 @@ func (h CiHandler) AddGroupHandler(w http.ResponseWriter, r *http.Request) {
 //	@Tags			admin,groups
 //	@Produce		json
 //	@Success		200	{object}	cistore.GroupData
+//	@Failure		404	{object}	nil
 //	@Failure		500	{object}	nil
 //	@Param			id	path		string	true	"Group ID"
 //	@Router			/admin/groups/{id} [get]
@@ -103,7 +105,11 @@ func (h CiHandler) GetGroupHandler(w http.ResponseWriter, r *http.Request) {
 
 	data, err = h.store.GetGroupData(id)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		if reflect.DeepEqual(data, cistore.GroupData{}) {
+			http.Error(w, err.Error(), http.StatusNotFound)
+		} else {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
 		return
 	}
 

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -169,6 +169,9 @@ const docTemplate = `{
                             "$ref": "#/definitions/cistore.GroupData"
                         }
                     },
+                    "404": {
+                        "description": "Not Found"
+                    },
                     "500": {
                         "description": "Internal Server Error"
                     }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -161,6 +161,9 @@
                             "$ref": "#/definitions/cistore.GroupData"
                         }
                     },
+                    "404": {
+                        "description": "Not Found"
+                    },
                     "500": {
                         "description": "Internal Server Error"
                     }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -363,6 +363,8 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/cistore.GroupData'
+        "404":
+          description: Not Found
         "500":
           description: Internal Server Error
       summary: Get data for single group


### PR DESCRIPTION
Closes #84 

Requesting a group that doesn't exist would return a 500 Internal Server Error, when a 404 Not Found would be more appropriate. This PR updates the code and the OpenAPI spec to reflect this change.

To test:

0. Start with clean cloud-init server.
1. `ochami -L basic cloud-init group get config nonexistent`
2. Output:
   ```
   ERROR | cloud_init-group-get.go:74 > cloud-init group request yielded unsuccessful HTTP response error="GetGroups(): failed to GET group from cloud-init: unsuccessful HTTP status: HTTP/2.0 404 Not Found: group (compute) not found\n"
   ```
3. In cloud-init logs:
   ```
   cloud-init-server[84700]: 2025/09/29 16:37:35 [cloud-init/m8u9Wq6ADy-000002] "GET http://demo.openchami.cluster:8443/admin/groups/compute HTTP/1.1" from 172.16.0.254 - 404 26B in 936.775µs
   cloud-init-server[84700]: 4:37PM INF Request bytes_in=0 bytes_out=26 duration=0.865364 method=GET remote_addr=172.16.0.254 request_id=cloud-init/m8u9Wq6ADy-000002 request_uri=/admin/groups/compute status="Not Found" status_code=404 user_agent=ochami/0.5.4
   ```