### PR TITLE
fix: improve error handling in MetaDataHandler and SMDClient

### DIFF
--- a/cmd/cloud-init-server/metadata_handlers.go
+++ b/cmd/cloud-init-server/metadata_handlers.go
@@ -56,7 +56,7 @@ func MetaDataHandler(smd smdclient.SMDClientInterface, store cistore.Store) http
 			id, err = smd.IDfromIP(ip)
 			if err != nil {
 				log.Print(err)
-				w.WriteHeader(http.StatusUnprocessableEntity)
+				http.Error(w, "Failed to retrieve node ID from IP address", http.StatusUnprocessableEntity)
 				return
 			} else {
 				log.Printf("xname %s with ip %s found\n", id, ip)

--- a/internal/smdclient/SMDclient.go
+++ b/internal/smdclient/SMDclient.go
@@ -194,6 +194,10 @@ func (s *SMDClient) getSMD(ep string, smd interface{}) error {
 		}
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		log.Error().Msgf("Failed to get SMD data: %s", resp.Status)
+		return fmt.Errorf("failed to get SMD data: %s", resp.Status)
+	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to read response body")


### PR DESCRIPTION
This pull request improves error handling and user feedback in the metadata handler and SMD client code. The changes focus on providing clearer error messages to clients and logging more informative errors for easier debugging.

**Error handling and user feedback improvements:**

* Updated the `MetaDataHandler` in `metadata_handlers.go` to use `http.Error` with a descriptive message when failing to retrieve a node ID from an IP address, instead of just setting the status code.
* Enhanced the `getSMD` method in `SMDclient.go` to log and return a detailed error if the response status code is not OK, improving visibility into SMD request failures.