### PR TITLE
feat: Initialize and start WireGuard server if configured

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN duckdb -c "INSTALL 'json';" \
 # -------- runtime image --------
 FROM ubuntu:24.04
 RUN apt-get update \
- && apt-get install -y --no-install-recommends ca-certificates wireguard-tools tini \
+ && apt-get install -y --no-install-recommends ca-certificates iproute2 wireguard-tools tini \
  && rm -rf /var/lib/apt/lists/*
 
 COPY cloud-init-server /usr/local/bin/cloud-init-server


### PR DESCRIPTION
This pull request adds support for initializing and running a WireGuard server within the `cloud-init-server` application. The main changes focus on conditionally starting the WireGuard server based on configuration, managing the WireGuard interface, and integrating it with the server's routing logic.

WireGuard server integration:

* Imports the `net` package to support parsing CIDR notation for WireGuard IP and netmask configuration.
* Adds logic to initialize and start a WireGuard server if the `wireguardServer` configuration is set, including error handling and logging for server startup.

Routing and middleware updates:

* Passes the new `wgInterfaceManager` to the client router initializer to enable route-level integration with the WireGuard server.
* Adds logging and ensures WireGuard middleware is enabled only when the server is configured, improving observability and correctness.