### PR TITLE
feat: handle base URL and fake SMD consistently

### DIFF
--- a/cmd/cloud-init-server/vendordata_handlers.go
+++ b/cmd/cloud-init-server/vendordata_handlers.go
@@ -24,10 +24,9 @@ import (
 //	@Param			id	path		string	false	"Node ID"
 //	@Router			/vendor-data [get]
 //	@Router			/admin/impersonation/{id}/vendor-data [get]
-func VendorDataHandler(smd smdclient.SMDClientInterface, store cistore.Store) http.HandlerFunc {
+func VendorDataHandler(smd smdclient.SMDClientInterface, store cistore.Store, baseUrl string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		urlId := chi.URLParam(r, "id")
-		var baseUrl string
 		var id = urlId
 		var err error
 		// If this request includes an id, it can be interrpreted as an impersonation request
@@ -74,9 +73,6 @@ func VendorDataHandler(smd smdclient.SMDClientInterface, store cistore.Store) ht
 		}
 		if extendedInstanceData.CloudInitBaseURL != "" {
 			baseUrl = extendedInstanceData.CloudInitBaseURL
-		}
-		if baseUrl == "" {
-			baseUrl = "http://cloud-init:27777"
 		}
 
 		payload := "#include\n"


### PR DESCRIPTION
These were previously options that were sorta halfway set up as CLI args, and are now fully set up as CLI args.

Add a --smd-simulator flag for the CLOUD_INIT_SMD_SIMULATOR and set the fakeSMDEnabled variable to it. Previously the envvar was used in some cases, and the variable in others, and nothing actually set the variable.

Previously the envvar enabled the fake SMD client, but did not expose the admin endpoints to manipulate the fake SMD, which relied on the unset `fakeSMD` var.

Pass baseUrl to the VendorDataHandler initializer and use it if none is set in the store. Previously this was only used for logging, and was effectively inaccurate as such.

Previously setting `BASE_URL` had no effect on VendorDataHandler (the only thing that uses it AFAIK); you hadd to use the cluster-defaults API endpoint to get anything other than the `http://cloud-init:27777` magic string baked into VendorDataHandler.